### PR TITLE
Fix typo in autoload source folder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     },
     "autoload": {
         "classmap": [
-            "scr/"
+            "src/"
         ]
     }
 }


### PR DESCRIPTION
Fix typo in `composer.json` as mentioned in #12 